### PR TITLE
feat(macos): add LaunchAgent to load SSH keys from Keychain at login

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Each subdir owns its own installer. Run it directly:
 ./git/install.sh
 ./ghostty/install.sh
 ./karabiner/install.sh
+./macos/install.sh
 ```
 
 ### What gets installed where
@@ -43,5 +44,19 @@ Each subdir owns its own installer. Run it directly:
 | `git/gitignore_global` | `~/.gitignore_global` |
 | `ghostty/config.ghostty` | `~/Library/Application Support/com.mitchellh.ghostty/config` |
 | `karabiner/karabiner.json` | `~/.config/karabiner/karabiner.json` |
+| `macos/com.user.ssh-add-keychain.plist` | `~/Library/LaunchAgents/com.user.ssh-add-keychain.plist` |
 
 `hammerspoon/` and `iterm2/` are tracked in the repo for reference but have no installer.
+
+### macOS LaunchAgents
+
+`macos/install.sh` symlinks the LaunchAgent and activates it via `launchctl`
+(no logout required). The `com.user.ssh-add-keychain` agent runs
+`ssh-add --apple-load-keychain` at login, which loads any SSH keys whose
+passphrases are saved in the Keychain into `ssh-agent`. It pairs with
+`AddKeysToAgent yes` + `UseKeychain yes` in `~/.ssh/config` so the agent is
+populated after every reboot — replacing the manual `ssh-add -A`
+(now `ssh-add --apple-load-keychain`) step.
+
+To disable it: `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.user.ssh-add-keychain.plist`
+then remove the symlink.

--- a/macos/com.user.ssh-add-keychain.plist
+++ b/macos/com.user.ssh-add-keychain.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.ssh-add-keychain</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/ssh-add</string>
+        <string>--apple-load-keychain</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+link() {
+  local src="$1" dst="$2"
+  mkdir -p "$(dirname "$dst")"
+  if [ -L "$dst" ] && [ "$(readlink "$dst")" = "$src" ]; then
+    echo "  $dst already linked"
+    return 0
+  fi
+  if [ -L "$dst" ]; then
+    echo "  replacing existing symlink $dst"
+    rm "$dst"
+  elif [ -e "$dst" ]; then
+    local backup="${dst}.backup"
+    if [ -e "$backup" ] || [ -L "$backup" ]; then
+      backup="${dst}.backup_$(date +%Y_%m_%d_%H%M%S)"
+    fi
+    echo "  backing up $dst to $backup"
+    mv "$dst" "$backup"
+  fi
+  ln -s "$src" "$dst"
+  echo "  linked $dst -> $src"
+}
+
+# LaunchAgent: load SSH keys whose passphrases are stored in the Keychain at
+# login. Pairs with `AddKeysToAgent yes` + `UseKeychain yes` in ~/.ssh/config so
+# the agent is populated after every reboot without a manual `ssh-add`.
+PLIST="com.user.ssh-add-keychain.plist"
+DST="$HOME/Library/LaunchAgents/$PLIST"
+
+link "$DIR/$PLIST" "$DST"
+
+# Activate now (idempotent). Newer macOS prefers bootstrap; fall back to load.
+if launchctl bootstrap "gui/$(id -u)" "$DST" 2>/dev/null; then
+  echo "  bootstrapped $PLIST"
+elif launchctl load "$DST" 2>/dev/null; then
+  echo "  loaded $PLIST"
+else
+  echo "  $PLIST already active (or will load at next login)"
+fi


### PR DESCRIPTION
Adds a macos/ subdir shipping com.user.ssh-add-keychain.plist, which runs `ssh-add --apple-load-keychain` at login to populate ssh-agent from the Keychain after every reboot. Pairs with AddKeysToAgent/UseKeychain in ~/.ssh/config, replacing the manual `ssh-add -A` step.

macos/install.sh follows the existing link() symlink+backup convention and activates the agent via launchctl. README updated with the new subdir, destination table row, and a macOS LaunchAgents section.